### PR TITLE
Update to ndarray-ops ^1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "gl-vao": "~0.0.1",
-    "ndarray-ops": "~1.1.0",
+    "ndarray-ops": "^1.2.2",
     "typedarray-pool": "~0.1.1",
     "webglew": "~0.0.0",
     "ndarray": "~1.0.0",


### PR DESCRIPTION
Updates gl-mesh's ndarray-ops semver dependency from ~1.1.0 to ^1.2.2. This most importantly causes a cwise-compiler update from 0.0.0 to 1.1.2.
