### PR TITLE
Skip drawing zero-length meshes. Fixes GH-2

### DIFF
--- a/lib/mesh.js
+++ b/lib/mesh.js
@@ -42,6 +42,7 @@ Mesh.prototype.dispose = function() {
 }
 
 Mesh.prototype.draw = function() {
+  if (this.numElements === 0) return;
   if(this.elements) {
     this.elements.draw(this.mode, this.numElements)
   } else {


### PR DESCRIPTION
Fixes https://github.com/mikolalysenko/gl-mesh/issues/2 Skip draw() if this.numElements===0? Chrome logs: RENDER WARNING: Render count or primcount is 0.
